### PR TITLE
Always set parent term during import

### DIFF
--- a/includes/TermFixtureImport.inc
+++ b/includes/TermFixtureImport.inc
@@ -83,8 +83,8 @@ class TermFixtureImport {
   }
 
   public function save() {
+    $parents = array();
     if (count($this->parents)) {
-      $parents = array();
       foreach ($this->parents as $parent) {
         $query = new EntityFieldQuery();
         $term = $query->entityCondition('entity_type', 'taxonomy_term')
@@ -92,8 +92,8 @@ class TermFixtureImport {
                     ->execute();
         $parents = array_merge($parents, array_keys($term['taxonomy_term']));
       }
-      $this->term->parent = $parents;
     }
+    $this->term->parent = $parents;
     taxonomy_term_save($this->term);
   }
 }

--- a/includes/TermFixtureImport.inc
+++ b/includes/TermFixtureImport.inc
@@ -93,6 +93,9 @@ class TermFixtureImport {
         $parents = array_merge($parents, array_keys($term['taxonomy_term']));
       }
     }
+    if (!count($parents)) {
+      $parents = array(0);
+    }
     $this->term->parent = $parents;
     taxonomy_term_save($this->term);
   }


### PR DESCRIPTION
Some contrib modules may throw errors if not. For instance:

``` php
/**
 * Implements hook_hook_taxonomy_term_update().
 */
function shs_taxonomy_term_update($term) {
  // Update vocabulary cache for the terms parents.
  foreach ($term->parent as $parent) {
    shs_term_get_children($term->vid, $parent, array('node_count' => TRUE), TRUE);
  }
}
```

This wouldn't be a problem if every contrib module `if(isset($term->parent))` but this is not the case.
